### PR TITLE
Idle ping

### DIFF
--- a/tests/integration/test_reconnect.py
+++ b/tests/integration/test_reconnect.py
@@ -8,6 +8,7 @@ class ReconnectTests(IntegrationTestCase):
     VERBOSE = False
 
     async def test_connection_drop_still_receives_events_after_reconnected(self):
+        await d2f(self.ledger.update_account(self.account))
         address1 = await d2f(self.account.receiving.get_or_create_usable_address())
         self.ledger.network.client.connectionLost()
         sendtxid = await self.blockchain.send_to_address(address1, 1.1337)

--- a/torba/baseledger.py
+++ b/torba/baseledger.py
@@ -355,11 +355,11 @@ class BaseLedger(metaclass=LedgerRegistry):
                 continue
             if remote_height > 0:
                 deferreds.append(
-                    self.network.get_merkle(hex_id, remote_height).addBoth(
+                    self.network.get_merkle(hex_id, remote_height).addCallback(
                         lambda result, txid: proofs.__setitem__(txid, result), hex_id)
                 )
             deferreds.append(
-                self.network.get_transaction(hex_id).addBoth(
+                self.network.get_transaction(hex_id).addCallback(
                     lambda result, txid: network_txs.__setitem__(txid, result), hex_id)
             )
         yield defer.DeferredList(deferreds)

--- a/torba/basenetwork.py
+++ b/torba/basenetwork.py
@@ -7,7 +7,6 @@ from twisted.application.internet import ClientService, CancelledError
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.task import LoopingCall
 from twisted.protocols.basic import LineOnlyReceiver
-from twisted.python import failure
 
 from torba import __version__
 from torba.stream import StreamController
@@ -119,7 +118,7 @@ class StratumClientProtocol(LineOnlyReceiver):
         return d
 
     def ping(self):
-        if len(self.lookup_table):
+        if self.lookup_table:
             return # we aren't idle
         # use server.ping when support for Stratum 1.0 gets dropped
         return self.rpc('server.version').addTimeout(


### PR DESCRIPTION
* remove per-request timeout so it doesnt raise on high load (as long as the server is working, there is no such case)
* ping if idle, as stratum protocol, to avoid being disconnected and check if connection is still working
* addBoth were used on prefetch, where the correct is addCallback